### PR TITLE
Add PHP 7 and HHVM Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,11 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7
+  - hhvm
 
 before_script:
   - curl -s http://getcomposer.org/installer | php
   - php composer.phar install --dev
 
 script: phpunit
-


### PR DESCRIPTION
Will make our test suite pass on newer versions of PHP, and add support for HHVM.
