### PR TITLE
Fixed problem for composer require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "keywords": ["laravel", "formatter", "data", "convert", "csv", "xml", "yaml"],
     "homepage": "http://github.com/SoapBox/laravel-formatter",
     "license": "MIT",
-    "version": "3.0",
+    "version": "3.1.1",
     "authors": [
         {
             "name": "Graham McCarthy",


### PR DESCRIPTION
The problem was that the version of the tag and the version in composer
json are not the same in tag 3.1 so it couldn't get found by composer.