### PR TITLE
Update package to support Laravel 6, phpunit 8 and PHP 7.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.phar
 composer.lock
 .DS_Store
 notes
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: php
 
 php:
-  - 7.0
-  - 7.1
   - 7.2
+  - 7.3
 
 before_script:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,13 @@
         }
     ],
     "require": {
-        "php" : ">=7.0.10",
+        "php": "^7.2",
         "league/csv": "~9.0",
         "mustangostang/spyc": "~0.6",
-        "illuminate/support": "~5.5"
+        "illuminate/support": "^6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7 || ^6.5"
+        "phpunit/phpunit": "~8.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
 >
     <testsuites>
         <testsuite name="Package Test Suite">

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,7 @@
 Changelog
 ================
 
+- Update support for Laravel 6 & phpunit 8
 - Update composer.json
 - Upgrade to PSR-4
 - add parameter newline, delimiter, enclosure, and escape to export csv

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,14 +6,14 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
     /**
      * Runs prior to every test in the suite.
      */
-    public function setUp()
+    public function setUp(): void
     {
     }
 
     /**
      * Runs after every test in the suite.
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
     }
 

--- a/tests/unit/FormatterTest.php
+++ b/tests/unit/FormatterTest.php
@@ -45,11 +45,10 @@ class FormatterTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testFormatterMakeThrowsInvalidTypeException()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $formatter = Formatter::make('', 'blue');
     }
 

--- a/tests/unit/Parsers/ArrayParserTest.php
+++ b/tests/unit/Parsers/ArrayParserTest.php
@@ -30,11 +30,10 @@ class ArrayParserTest extends TestCase
         $this->assertEquals($expected, $parser->toArray());
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testArrayParserThrowsExceptionWithInvalidInputOfEmptyString()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $parser = new ArrayParser('');
     }
 

--- a/tests/unit/Parsers/CsvParserDelemiterTest.php
+++ b/tests/unit/Parsers/CsvParserDelemiterTest.php
@@ -15,12 +15,11 @@ bar;far';
         $parser = new CsvParser('', ';');
         $this->assertTrue($parser instanceof Parser);
     }
-
-    /**
-     * @expectedException InvalidArgumentException
-     */
+    
     public function testConstructorThrowsInvalidExecptionWhenArrayDataIsProvided()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        
         $parser = new CsvParser([0, 1, 3], ';');
     }
 

--- a/tests/unit/Parsers/CsvParserTest.php
+++ b/tests/unit/Parsers/CsvParserTest.php
@@ -15,12 +15,11 @@ bar,far';
         $parser = new CsvParser('');
         $this->assertTrue($parser instanceof Parser);
     }
-
-    /**
-     * @expectedException InvalidArgumentException
-     */
+    
     public function testConstructorThrowsInvalidExecptionWhenArrayDataIsProvided()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        
         $parser = new CsvParser([0, 1, 3]);
     }
 


### PR DESCRIPTION
If this pull request gets merged it applies the following changes:

+ bumps the `illuminate/support` package to `6.0`
+ bumps the `phpunit/phpunit` to version `~8.0`
+ Laravel 6 requires php to be in version 7.2, so that change also applies
+ Fixes tests to stop using the `@expectedException` notation as it will be deprecated in Phpunit 9 and refactors to use the `$this->expectException(\InvalidArgumentException::class);` instead
+ updates the testcase to now include the void return type required by phpunit 8