### PR TITLE
Fix Laravel version requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php": "^7.2",
         "league/csv": "~9.0",
         "mustangostang/spyc": "~0.6",
-        "illuminate/support": "^6.0"
+        "illuminate/support": "^6"
     },
     "require-dev": {
         "phpunit/phpunit": "~8.0"


### PR DESCRIPTION
Since Laravel 6 comes with semver, updates shouldn't contain breaking changes for the whole 6.x branch. Requiring illuminate/support ^6.0 should become ^6